### PR TITLE
Fixes a bug that prevented enqueue script conditional from working.

### DIFF
--- a/lib/Factories/Enqueue_Script_Conditional.php
+++ b/lib/Factories/Enqueue_Script_Conditional.php
@@ -47,6 +47,7 @@ class Enqueue_Script_Conditional extends Enqueue_Conditional {
 
 	public function update( $instance, Storage $args ) {
 		parent::update( $instance, $args );
+		$this->loader_item = $instance;
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue' ] );
 	}
 

--- a/lib/Factories/Enqueue_Script_Conditional.php
+++ b/lib/Factories/Enqueue_Script_Conditional.php
@@ -27,27 +27,12 @@ class Enqueue_Script_Conditional extends Enqueue_Conditional {
 		parent::__construct( $args );
 	}
 
-	public function enqueue() {
-		// Only enqueue if this is the block editor.
-		if ( $this->should_enqueue() ) {
-			if ( $this->loader_item instanceof Script ) {
-				$this->loader_item->enqueue();
-			} else {
-				Logger::log( 'warning', 'rest_middleware_action_failed_to_run', 'Middleware action failed to run. Rest_Middleware expects to run on a Script loader.', [
-					'loader'  => get_class( $this->loader_item ),
-					'expects' => 'Underpin\Scripts\Abstracts\Script',
-				] );
-			}
-		}
-	}
-
 	protected function should_enqueue() {
 		return $this->set_callable( $this->should_enqueue_callback, $this->loader_item );
 	}
 
 	public function update( $instance, Storage $args ) {
 		parent::update( $instance, $args );
-		$this->loader_item = $instance;
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue' ] );
 	}
 


### PR DESCRIPTION
There was a legacy `enqueue` method incorrectly added to the `Enqueue_Script_Conditional` class that no-longer needed to be there. This method conflicted with the parent `enqueue` class and prevented it from working as-expected.